### PR TITLE
Add script to parse unique ip addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ Change directory to cloned repo:
 Build/run containers from docker-compose.yml:
 
 `docker-compose up -d --build`
+
+# Exercise 2
+
+## Getting started
+
+Change directory to cloned repo:
+
+`cd /path/to/ba-exercise`
+
+Run the python script, using the URI as an argument:
+
+`./log_parse.py https://bit.ly/3hFzUzs`

--- a/log_parse.py
+++ b/log_parse.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import re
+import requests
+import sys
+
+def main(URI):
+    ip_list = []
+
+    try:
+        response = requests.get(URI)
+        response.raise_for_status()
+    except Exception as execinfo:
+        print(str(execinfo.args[0]))
+
+    for line in response.text.splitlines():
+        match = re.search(r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', line)
+        if match:
+            ip_list.append(match.group())
+    
+    print(set(ip_list))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])


### PR DESCRIPTION
This script takes a URI as input and parses the response for unique IP addresses. 
Once the log is completely parsed, all unique IP addresses are printed to STDOUT.

There are two different implementations that I experimented with while creating this script:
1. Add each ip address to the list and return a `set` object, which removes duplicate entries.
2. Check first if a given IP address appeared in the final list. If not, I would add the IP address.

Using the `time` module, I was able to calculate the execution time for each implementation.

I found that implementation 1. resulted in an average execution time of 0.26 seconds, while implementation 2. resulted in an average execution time of 0.36 seconds, approximately .10 seconds slower.
